### PR TITLE
Allow to compile properly

### DIFF
--- a/SmoothServo.cpp
+++ b/SmoothServo.cpp
@@ -4,6 +4,12 @@
   Released into the public domain.
 */
 
+#if defined(ARDUINO) && ARDUINO >= 100
+  #include "Arduino.h"
+#else
+  #include "WProgram.h"
+#endif
+
 #include <Servo.h>
 #include "SmoothServo.h"
 


### PR DESCRIPTION
Avoid the error delay(5000); not declared